### PR TITLE
Implement optional separate login URL for Piazzetta use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ from py_agua_iot import agua_iot
 # 635987 => customer code of Eva Calor
 # 1c3be3cd-360c-4c9f-af15-1f79e9ccbc2a => random UUID (you can generate one here: https://www.uuidgenerator.net/version4)
 # brand_id="1" => optional brand id (should always be "1" but can be overridden just in case)
+# login_api_url="" => optional separate login URL (used for Piazzetta for example)
 connection = agua_iot("https://evastampaggi.agua-iot.com", "635987", "john.smith@gmail.com", "mysecretpassword", "1c3be3cd-360c-4c9f-af15-1f79e9ccbc2a", brand_id="1")
 
 # Print the current air temperature for each device
@@ -24,38 +25,38 @@ for device in connection.devices:
 
 Below you can find a table with the app names of the different stove brands and their corresponding customer code and API URL.
 
-| App name or Brand             | Customer Code | API URL                                |
-| ----------------------------- | ------------- | -------------------------------------- |
-| EvaCalòr - PuntoFuoco         | 635987        | https://evastampaggi.agua-iot.com      |
-| Elfire Wifi                   | 402762        | https://elfire.agua-iot.com            |
-| Karmek Wifi                   | 403873        | https://karmekone.agua-iot.com         |
-| Easy Connect                  | 354924        | https://remote.mcz.it                  |
-| Easy Connect Plus             | 746318        | https://remote.mcz.it                  |
-| Easy Connect Poêle            | 354925        | https://remote.mcz.it                  |
-| Lorflam Home                  | 121567        | https://lorflam.agua-iot.com           |
-| LMX Remote Control            | 352678        | https://laminox.agua-iot.com           |
-| Boreal Home                   | 173118        | https://boreal.agua-iot.com            |
-| Bronpi Home                   | 164873        | https://bronpi.agua-iot.com            |
-| EOSS WIFI                     | 326495        | https://solartecnik.agua-iot.com       |
-| LAMINOXREM REMOTE CONTROL 2.0 | 352678        | https://laminox.agua-iot.com           |
-| Jolly Mec Wi Fi               | 732584        | https://jollymec.agua-iot.com          |
-| Globe-fire                    | 634876        | https://globefire.agua-iot.com         |
-| TS Smart                      | 046629        | https://timsistem.agua-iot.com         |
-| Stufe a pellet Italia         | 015142        | https://stufepelletitalia.agua-iot.com |
-| My Corisit                    | 101427        | https://mycorisit.agua-iot.com         |
-| Fonte Flamme contrôle 1       | 848324        | https://fonteflame.agua-iot.com        |
-| Klover Home                   | 143789        | https://klover.agua-iot.com            |
-| Nordic Fire 2.0               | 132678        | https://nordicfire.agua-iot.com        |
-| GO HEAT                       | 859435        | https://amg.agua-iot.com               |
-| Wi-Phire                      | 521228        | https://lineavz.agua-iot.com           |
-| Thermoflux                    | 391278        | https://thermoflux.agua-iot.com        |
-| Darwin Evolution              | 475219        | https://cola.agua-iot.com              |
-| Moretti design                | 624813        | https://moretti.agua-iot.com           |
-| Fontana Forni                 | 505912        | https://fontanaforni.agua-iot.com      |
-| MyPiazzetta (MySuperior?)     | 458632        | https://piazzetta.agua-iot.com         |
-| Alfaplam                      | 862148        | https://alfaplam.agua-iot.com          |
-| Nina                          | 999999        | https://micronova.agua-iot.com         |
-| Galletti                      | ?             | ?                                      |
+| App name or Brand             | Customer Code | API URL                                | Separate login URL (only needed if specified)         |
+| ----------------------------- | ------------- | -------------------------------------- | ----------------------------------------------------- |
+| EvaCalòr - PuntoFuoco         | 635987        | https://evastampaggi.agua-iot.com      |                                                       |
+| Elfire Wifi                   | 402762        | https://elfire.agua-iot.com            |                                                       |
+| Karmek Wifi                   | 403873        | https://karmekone.agua-iot.com         |                                                       |
+| Easy Connect                  | 354924        | https://remote.mcz.it                  |                                                       |
+| Easy Connect Plus             | 746318        | https://remote.mcz.it                  |                                                       |
+| Easy Connect Poêle            | 354925        | https://remote.mcz.it                  |                                                       |
+| Lorflam Home                  | 121567        | https://lorflam.agua-iot.com           |                                                       |
+| LMX Remote Control            | 352678        | https://laminox.agua-iot.com           |                                                       |
+| Boreal Home                   | 173118        | https://boreal.agua-iot.com            |                                                       |
+| Bronpi Home                   | 164873        | https://bronpi.agua-iot.com            |                                                       |
+| EOSS WIFI                     | 326495        | https://solartecnik.agua-iot.com       |                                                       |
+| LAMINOXREM REMOTE CONTROL 2.0 | 352678        | https://laminox.agua-iot.com           |                                                       |
+| Jolly Mec Wi Fi               | 732584        | https://jollymec.agua-iot.com          |                                                       |
+| Globe-fire                    | 634876        | https://globefire.agua-iot.com         |                                                       |
+| TS Smart                      | 046629        | https://timsistem.agua-iot.com         |                                                       |
+| Stufe a pellet Italia         | 015142        | https://stufepelletitalia.agua-iot.com |                                                       |
+| My Corisit                    | 101427        | https://mycorisit.agua-iot.com         |                                                       |
+| Fonte Flamme contrôle 1       | 848324        | https://fonteflame.agua-iot.com        |                                                       |
+| Klover Home                   | 143789        | https://klover.agua-iot.com            |                                                       |
+| Nordic Fire 2.0               | 132678        | https://nordicfire.agua-iot.com        |                                                       |
+| GO HEAT                       | 859435        | https://amg.agua-iot.com               |                                                       |
+| Wi-Phire                      | 521228        | https://lineavz.agua-iot.com           |                                                       |
+| Thermoflux                    | 391278        | https://thermoflux.agua-iot.com        |                                                       |
+| Darwin Evolution              | 475219        | https://cola.agua-iot.com              |                                                       |
+| Moretti design                | 624813        | https://moretti.agua-iot.com           |                                                       |
+| Fontana Forni                 | 505912        | https://fontanaforni.agua-iot.com      |                                                       |
+| MyPiazzetta (MySuperior?)     | 458632        | https://piazzetta.agua-iot.com         | https://piazzetta.iot.web2app.it/api/bridge/endpoint/ |
+| Alfaplam                      | 862148        | https://alfaplam.agua-iot.com          |                                                       |
+| Nina                          | 999999        | https://micronova.agua-iot.com         |                                                       |
+| Galletti                      | ?             | ?                                      |                                                       |
 
 If you happen to know any extra or missing customer codes and API URL's, please feel free to open a pull request and add them to the table above.
 

--- a/examples/home-assistant/custom_components/aguaiot/climate.py
+++ b/examples/home-assistant/custom_components/aguaiot/climate.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_API_URL,
     CONF_BRAND_ID,
     CONF_CUSTOMER_CODE,
+    CONF_LOGIN_API_URL,
     CONF_UUID,
     DOMAIN,
     AGUA_STATUS_CLEANING,
@@ -65,9 +66,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
     email = entry.data[CONF_EMAIL]
     password = entry.data[CONF_PASSWORD]
     gen_uuid = entry.data[CONF_UUID]
+    login_api_url = entry.data[CONF_LOGIN_API_URL]
 
     try:
-        agua = await hass.async_add_executor_job(agua_iot, api_url, customer_code, email, password, gen_uuid, brand_id)
+        agua = await hass.async_add_executor_job(agua_iot, api_url, customer_code, email, password, gen_uuid, brand_id, login_api_url)
         device = agua.devices[0]
     except UnauthorizedError:
         _LOGGER.error("Wrong credentials for Agua IOT")

--- a/examples/home-assistant/custom_components/aguaiot/config_flow.py
+++ b/examples/home-assistant/custom_components/aguaiot/config_flow.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_API_URL,
     CONF_BRAND_ID,
     CONF_CUSTOMER_CODE,
+    CONF_LOGIN_API_URL,
     CONF_UUID,
     DOMAIN
 )
@@ -56,13 +57,14 @@ class AguaIOTConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             api_url = user_input[CONF_API_URL]
             customer_code = user_input[CONF_CUSTOMER_CODE]
             brand_id = user_input[CONF_BRAND_ID]
+            login_api_url = user_input[CONF_LOGIN_API_URL]
 
             if self._entry_in_configuration_exists(user_input):
                 return self.async_abort(reason="device_already_configured")
 
             try:
                 gen_uuid = str(uuid.uuid1())
-                agua_iot(api_url, customer_code, email, password, gen_uuid, brand_id=brand_id)
+                agua_iot(api_url, customer_code, email, password, gen_uuid, brand_id=brand_id, login_api_url=login_api_url)
             except UnauthorizedError:
                 errors["base"] = "unauthorized"
             except ConnectionError:
@@ -79,7 +81,8 @@ class AguaIOTConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_UUID: gen_uuid,
                         CONF_API_URL: api_url,
                         CONF_CUSTOMER_CODE: customer_code,
-                        CONF_BRAND_ID: brand_id
+                        CONF_BRAND_ID: brand_id,
+                        CONF_LOGIN_API_URL: login_api_url
                     },
                 )
         else:
@@ -88,6 +91,9 @@ class AguaIOTConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         data_schema = OrderedDict()
         data_schema[
             vol.Required(CONF_API_URL, default=user_input.get(CONF_API_URL))
+        ] = str
+        data_schema[
+            vol.Required(CONF_LOGIN_API_URL, default=None)
         ] = str
         data_schema[
             vol.Required(CONF_CUSTOMER_CODE,

--- a/examples/home-assistant/custom_components/aguaiot/const.py
+++ b/examples/home-assistant/custom_components/aguaiot/const.py
@@ -11,6 +11,7 @@ ATTR_SMOKE_TEMP = "smoke_temperature"
 CONF_API_URL = "api_url"
 CONF_BRAND_ID = "brand_id"
 CONF_CUSTOMER_CODE = "customer_code"
+CONF_LOGIN_API_URL = "login_api_url"
 CONF_UUID = "uuid"
 
 AGUA_STATUS_CLEANING = "CLEANING FIRE-POT"

--- a/examples/home-assistant/custom_components/aguaiot/manifest.json
+++ b/examples/home-assistant/custom_components/aguaiot/manifest.json
@@ -2,8 +2,8 @@
   "domain": "aguaiot",
   "name": "Micronova Agua IOT",
   "documentation": "https://github.com/fredericvl/py-agua-iot/tree/master/examples/home-assistant",
-  "version": "0.0.6",
-  "requirements": ["py-agua-iot==0.0.6"],
+  "version": "0.0.7",
+  "requirements": ["py-agua-iot==0.0.7"],
   "dependencies": [],
   "codeowners": ["@fredericvl"],
   "config_flow": true

--- a/examples/home-assistant/custom_components/aguaiot/strings.json
+++ b/examples/home-assistant/custom_components/aguaiot/strings.json
@@ -6,6 +6,7 @@
         "description": "[%key:common::config_flow::description%]",
         "data": {
           "api_url": "[%key:common::config_flow::data::api_url%]",
+          "login_api_url": "[%key:common::config_flow::data::login_api_url%]",
           "customer_code": "[%key:common::config_flow::data::customer_code%]",
           "brand_id": "[%key:common::config_flow::data::brand_id%]",
           "email": "[%key:common::config_flow::data::email%]",

--- a/examples/home-assistant/custom_components/aguaiot/translations/en.json
+++ b/examples/home-assistant/custom_components/aguaiot/translations/en.json
@@ -12,6 +12,7 @@
             "user": {
                 "data": {
                     "api_url": "Agua IOT URL of brand",
+                    "login_api_url": "Separate login API URL (optional, only specify when needed)",
                     "customer_code": "Customer code of brand",
                     "brand_id": "Brand id (by default: 1)",
                     "email": "Email address",

--- a/py_agua_iot/__init__.py
+++ b/py_agua_iot/__init__.py
@@ -28,6 +28,7 @@ API_PATH_DEVICE_REGISTERS_MAP = "/deviceGetRegistersMap"
 API_PATH_DEVICE_BUFFER_READING = "/deviceGetBufferReading"
 API_PATH_DEVICE_JOB_STATUS = "/deviceJobStatus/"
 API_PATH_DEVICE_WRITING = "/deviceRequestWriting"
+API_LOGIN_APPLICATION_VERSION = "1.6.0"
 DEFAULT_TIMEOUT_VALUE = 5
 
 HEADER_ACCEPT = (
@@ -52,7 +53,7 @@ class agua_iot(object):
         16: "?", 17: "?", 18: "?", 19: "?"
     }
 
-    def __init__(self, api_url, customer_code, email, password, unique_id, brand_id=1, debug=False):
+    def __init__(self, api_url, customer_code, email, password, unique_id, login_api_url=None, brand_id=1, debug=False):
         """agua_iot object constructor"""
         if debug is True:
             _LOGGER.setLevel(logging.DEBUG)
@@ -80,6 +81,7 @@ class agua_iot(object):
         self.password = password
         self.unique_id = unique_id
         self.brand_id = str(brand_id)
+        self.login_api_url = login_api_url
 
         self.token = None
         self.token_expires = None
@@ -154,6 +156,13 @@ class agua_iot(object):
 
         headers = self._headers()
         headers.update(extra_headers)
+
+        if self.login_api_url is not None:
+            extra_login_headers = {
+                'applicationversion': API_LOGIN_APPLICATION_VERSION,
+                'url': API_PATH_LOGIN.lstrip("/")
+            }
+            headers.update(extra_login_headers)
 
         try:
             response = requests.post(url,

--- a/py_agua_iot/__init__.py
+++ b/py_agua_iot/__init__.py
@@ -163,6 +163,7 @@ class agua_iot(object):
                 'url': API_PATH_LOGIN.lstrip("/")
             }
             headers.update(extra_login_headers)
+            url = self.login_api_url
 
         try:
             response = requests.post(url,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="py-agua-iot",
-    version="0.0.6",
+    version="0.0.7",
     author="Frederic Van Linthoudt",
     author_email="frederic.van.linthoudt@gmail.com",
     description="py-agua-iot provides controlling heating devices connected via the IOT Agua platform of Micronova",


### PR DESCRIPTION
The separate login URL can be specified via the constructor of the module (`login_api_url="https://REPLACE_ME"`) so it is "future proof" in case any other brands are also requiring such a bridge endpoint.

The extra headers that are being passed through the separate login URL are:
* `url: userLogin`
* `applicationversion: 1.6.0`

The version specified in `applicationversion` doesn't really matter as specifying `99.0.0` at the moment of testing also worked.

The separate login URL serves as a proxy to the Agua IOT URL where the `url` header is telling to which URL path the request needs to be proxied to.

Fixes #8 