### PR TITLE
Use temp_probe_k_get as a fallback for property gas_temperature

### DIFF
--- a/py_agua_iot/__init__.py
+++ b/py_agua_iot/__init__.py
@@ -620,7 +620,10 @@ class Device(object):
 
     @property
     def gas_temperature(self):
-        return float(self.__get_information_item('temp_gas_flue_get'))
+        try:
+            return float(self.__get_information_item('temp_gas_flue_get'))
+        except Exception as err:
+            return float(self.__get_information_item('temp_probe_k_get'))
 
     @property
     def real_power(self):


### PR DESCRIPTION
Some stoves expose the `temp_probe_k_get` reg type instead of `temp_gas_flue_get`. This makes the module throw an exception:

```
  File "/Users/yves/git/yves/py-agua-iot/py_agua_iot/__init__.py", line 623, in gas_temperature
    return float(self.__get_information_item('temp_gas_flue_get'))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yves/git/yves/py-agua-iot/py_agua_iot/__init__.py", line 440, in __get_information_item
    formula = self.__register_map_dict[item]['formula']
              ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
KeyError: 'temp_gas_flue_get'
```

It also makes the Home Assistant integration setup fail as the attribute is called here: https://github.com/vincentwolsink/home_assistant_micronova_agua_iot/blob/master/custom_components/aguaiot/const.py#L9

Related issues/more context: 
https://github.com/fredericvl/py-agua-iot/issues/4#issuecomment-787040488
https://github.com/fredericvl/py-agua-iot/issues/53
